### PR TITLE
Set angular stdev of a single tag pose observation to Infinity

### DIFF
--- a/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
@@ -61,6 +61,9 @@ public class VisionSubsystem extends SubsystemBase {
     /** Baseline angular standard deviation used for vision observations. */
     public static final double ANGULAR_STDDEV_BASELINE = 0.05;
 
+    /** Ignore rotation corrections from single-tag solves. */
+    public static final double SINGLE_TAG_ANGULAR_STDDEV = Double.POSITIVE_INFINITY;
+
     /** Maximum allowable height (Z-axis) of a detected pose to be considered valid. */
     public static final double MAX_Z_METERS = 0.75;
 
@@ -232,7 +235,10 @@ public class VisionSubsystem extends SubsystemBase {
                 double stdDevFactor = computeStdDevFactor(camera, result, poseRecord);
 
                 double linearStdDev = LINEAR_STDDEV_BASELINE * stdDevFactor;
-                double angularStdDev = ANGULAR_STDDEV_BASELINE * stdDevFactor;
+                double angularStdDev =
+                        poseRecord.tagsUsed().size() == 1
+                                ? SINGLE_TAG_ANGULAR_STDDEV
+                                : ANGULAR_STDDEV_BASELINE * stdDevFactor;
 
                 robotState.addVisionObservation(
                         new VisionPoseObservation(


### PR DESCRIPTION
Ignore rotation corrections from single tag solves. Successfully tested in sim:
- Logged number of results (and looked at number of accepted results in A-Scope)
- Logged number of tags
- Logged the standard deviation to verify that the code worked correctly.
- Drove the robot around in sim to test the scenarios